### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,30 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: buildkite-agent-scaler
+spec:
+  owner: systems-engineering
+  domain: development-platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: buildkite-agent-scaler
+  title: Buildkite Agent Scaler
+  description: 📈A lambda for scaling an AutoScalingGroup based on Buildkite metrics
+  tags:
+    - go
+    - shell
+    - makefile
+  annotations:
+    backstage.io/source-location: url:https://github.com/Zegocover/buildkite-agent-scaler/
+    backstage.io/techdocs-ref: dir:.
+    buildkite.com/project-slug: tego/buildkite-agent-scaler
+    snyk.io/org-id: 276f1e65-4e71-4504-b35f-5a907c1779e8
+    snyk.io/targets: Zegocover/buildkite-agent-scaler
+  links: []
+spec:
+  type: service
+  owner: systems-engineering
+  lifecycle: deprecated
+  system: buildkite-agent-scaler


### PR DESCRIPTION
## Summary
- Adds `catalog-info.yaml` to register this repo in Backstage
- No Buildkite pipeline found — developer portal step skipped
- Defines System entity and Component entity with Snyk, Buildkite, and source annotations

## Details
- **Type:** service
- **Owner:** systems-engineering
- **Domain:** development-platform
- **Lifecycle:** deprecated

Generated as part of the Backstage catalog rollout across Zegocover repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)